### PR TITLE
VSCode debugging configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Build and Run",
+			"preLaunchTask": "npm: build",
+			"program": "${workspaceFolder}/index.js",
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "Open browser",
+			"linux": {
+				"command": "xdg-open",
+				"args": [
+					"http://localhost:8080"
+				]
+			}
+		},
+		{
+			"type": "npm",
+			"script": "start",
+			"problemMatcher": [
+				"$tsc"
+			]
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,7 +19,8 @@
 				"args": [
 					"http://localhost:8080"
 				]
-			}
+			},
+			"problemMatcher": []
 		},
 		{
 			"type": "npm",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,6 +20,20 @@
 					"http://localhost:8080"
 				]
 			},
+			"windows": {
+				"command": "cmd",
+				"args": [
+					"/c",
+					"start",
+					"https://localhost:8080"
+				]
+			},
+			"osx": {
+				"command": "open",
+				"args": [
+					"https://localhost:8080"
+				]
+			},
 			"problemMatcher": []
 		},
 		{


### PR DESCRIPTION
Allows for building and running the web app through VS Code.

Unfortunately, I haven't yet figured out a way to get Chrome or a browser launched to pull up the development site when the task runs. If I can figure that out, this would be a lot nicer.